### PR TITLE
Install/use latest Ocean

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,10 @@
 	"image": "docker.io/dwavesys/ocean-dev:latest",
 
 	// install repo requirements on create and content update
-	"updateContentCommand": "pip install -r requirements.txt",
+	// NOTE: we currently use deprecated pip resolver to prevent codespace build from failing,
+	// because we know latest dagviz is clashing with latest Ocean due to conflicting
+	// requirements on a shared dependency, networkx.
+	"updateContentCommand": "pip install -r requirements.txt --use-deprecated=legacy-resolver",
 
 	// forward/expose container services (relevant only when run locally)
 	"forwardPorts": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-dwave-ocean-sdk>=7.0.0
+dwave-ocean-sdk>=8.1.0
 dagviz>=0.4.0


### PR DESCRIPTION
Due to latest `dagviz` requiring `networkx<3` we can't install it with Ocean 7+ without dependency conflicts.

As a temporary fix, we use pip's legacy resolver.

The proper fix is to lower nx bound in Ocean, or increase the upper nx bound in dagviz.